### PR TITLE
修复电信协议提交长短信 ServiceId属性为空的bug

### DIFF
--- a/src/main/java/com/zx/sms/codec/smgp/msg/SMGPSubmitMessage.java
+++ b/src/main/java/com/zx/sms/codec/smgp/msg/SMGPSubmitMessage.java
@@ -525,6 +525,7 @@ public class SMGPSubmitMessage extends SMGPBaseMessage implements LongSMSMessage
 	
 	public SMGPSubmitMessage clone() throws CloneNotSupportedException {
 		SMGPSubmitMessage cloned = new SMGPSubmitMessage();
+		cloned.setServiceId(this.getServiceId());
 		cloned.setAtTime(this.getAtTime());
 		cloned.setChargeTermId(this.getChargeTermId());
 		cloned.setChargeTermPseudo(this.getChargeTermPseudo());


### PR DESCRIPTION
电信提交对象SMGPSubmitMessage clone方法增加ServiceId属性