### PR TITLE
CMPP 状态报告默认值修改

### DIFF
--- a/src/main/java/com/zx/sms/codec/cmpp/msg/CmppSubmitRequestMessage.java
+++ b/src/main/java/com/zx/sms/codec/cmpp/msg/CmppSubmitRequestMessage.java
@@ -33,7 +33,7 @@ public class CmppSubmitRequestMessage extends DefaultMessage implements LongSMSM
 	private static final long serialVersionUID = 1369427662600486133L;
 	private MsgId msgid = new MsgId();
 
-	private short registeredDelivery = 0;
+	private short registeredDelivery = 1;
 	private short msglevel = 9;
 	private String serviceId = GlobalConstance.emptyString;
 	private short feeUserType = 2;


### PR DESCRIPTION
电信-SMGP、联通-SGIP、国际-SMPP 状态报告都是默认需要，移动-CMPP建议也默认需要状态报告